### PR TITLE
Link travis badge to correct build URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 PhpStorm / IntelliJ Drupal Symfony Bridge
 ==========================
-[![Build Status](https://travis-ci.org/Haehnchen/idea-php-drupal-symfony2-bridge.svg?branch=master)](https://travis-ci.org/Haehnchen/idea-php-symfony2-plugin)
+[![Build Status](https://travis-ci.org/Haehnchen/idea-php-drupal-symfony2-bridge.svg?branch=master)](https://travis-ci.org/Haehnchen/idea-php-drupal-symfony2-bridge)
 [![Version](http://phpstorm.espend.de/badge/7487/version)](https://plugins.jetbrains.com/plugin/7487)
 [![Downloads](http://phpstorm.espend.de/badge/7487/downloads)](https://plugins.jetbrains.com/plugin/7487)
 [![Downloads last month](http://phpstorm.espend.de/badge/7487/last-month)](https://plugins.jetbrains.com/plugin/7487)


### PR DESCRIPTION
Hey, thanks for this.

Just noticed this small error in the build badge that it links to another repo job, which is probably not on purpose :)

Thanks again, have a great day!